### PR TITLE
feat: Make Bedrock IAM policy region restriction configurable

### DIFF
--- a/pod-identity-roles.tf
+++ b/pod-identity-roles.tf
@@ -405,27 +405,35 @@ locals {
   ]
 
   # Build policy statements based on capabilities
-  bedrock_invoke_statement = contains(var.bedrock_capabilities, "invoke") ? [{
-    Effect   = "Allow"
-    Action   = ["bedrock:InvokeModel"]
-    Resource = local.bedrock_model_arns
-    Condition = {
-      StringEquals = {
-        "aws:RequestedRegion" = var.bedrock_allowed_regions
+  bedrock_invoke_statement = contains(var.bedrock_capabilities, "invoke") ? [merge(
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock:InvokeModel"]
+      Resource = local.bedrock_model_arns
+    },
+    length(var.bedrock_allowed_regions) > 0 ? {
+      Condition = {
+        StringEquals = {
+          "aws:RequestedRegion" = var.bedrock_allowed_regions
+        }
       }
-    }
-  }] : []
+    } : {}
+  )] : []
 
-  bedrock_streaming_statement = contains(var.bedrock_capabilities, "streaming") ? [{
-    Effect   = "Allow"
-    Action   = ["bedrock:InvokeModelWithResponseStream"]
-    Resource = local.bedrock_model_arns
-    Condition = {
-      StringEquals = {
-        "aws:RequestedRegion" = var.bedrock_allowed_regions
+  bedrock_streaming_statement = contains(var.bedrock_capabilities, "streaming") ? [merge(
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock:InvokeModelWithResponseStream"]
+      Resource = local.bedrock_model_arns
+    },
+    length(var.bedrock_allowed_regions) > 0 ? {
+      Condition = {
+        StringEquals = {
+          "aws:RequestedRegion" = var.bedrock_allowed_regions
+        }
       }
-    }
-  }] : []
+    } : {}
+  )] : []
 
   bedrock_model_catalog_statement = contains(var.bedrock_capabilities, "model_catalog") ? [{
     Effect = "Allow"

--- a/variables.tf
+++ b/variables.tf
@@ -425,9 +425,9 @@ variable "bedrock_custom_model_arns" {
 }
 
 variable "bedrock_allowed_regions" {
-  description = "List of AWS regions where Bedrock API calls are allowed. Provides additional security control beyond model ARNs."
+  description = "List of AWS regions where Bedrock API calls are allowed. Empty list allows all regions. Provides additional security control beyond model ARNs."
   type        = list(string)
-  default     = ["us-east-1", "us-west-2"]
+  default     = []
 }
 
 ################################################################################


### PR DESCRIPTION
- Change bedrock_allowed_regions default from ["us-east-1", "us-west-2"] to []
- Make Condition block conditional - only applied when regions are specified
- Empty list (default) now allows all regions