### PR TITLE
feat: add EFS CSI IAM role for Pod Identity

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,11 @@ output "ebs_csi_iam_role_arn" {
   value       = try(aws_iam_role.ebs_csi[0].arn, null)
 }
 
+output "efs_csi_iam_role_arn" {
+  description = "EFS CSI IAM role ARN"
+  value       = try(aws_iam_role.efs_csi[0].arn, null)
+}
+
 output "cluster_autoscaler_iam_role_arn" {
   description = "Cluster Autoscaler IAM role ARN"
   value       = try(aws_iam_role.cluster_autoscaler[0].arn, null)

--- a/pod-identity-roles.tf
+++ b/pod-identity-roles.tf
@@ -47,6 +47,28 @@ resource "aws_iam_role_policy_attachment" "ebs_csi" {
 }
 
 ################################################################################
+# EFS CSI Driver IAM Role
+################################################################################
+
+data "aws_iam_policy" "efs_csi" {
+  count = var.create ? 1 : 0
+  name  = "AmazonEFSCSIDriverPolicy"
+}
+
+resource "aws_iam_role" "efs_csi" {
+  count              = var.create ? 1 : 0
+  name               = "${var.cluster_name}-efs-csi"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_trust[0].json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "efs_csi" {
+  count      = var.create ? 1 : 0
+  role       = aws_iam_role.efs_csi[0].name
+  policy_arn = data.aws_iam_policy.efs_csi[0].arn
+}
+
+################################################################################
 # Cluster Autoscaler IAM Role
 ################################################################################
 


### PR DESCRIPTION
## Summary
- Add IAM role and policy attachment for the EFS CSI driver following existing EBS CSI pattern
- Enables EFS dynamic provisioning on EKS clusters with Pod Identity

## Files changed
- `pod-identity-roles.tf` — EFS CSI role + policy attachment
- `outputs.tf` — `efs_csi_iam_role_arn` output

## Deploy order
This must be applied **before** nx-infra-tf (EFS filesystem + CSI addon)