### PR TITLE
Add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to release workflow
- Allows manual re-triggering after shared-workflows calver fix

## Test plan
- [ ] Merge and manually trigger release to verify shared workflow works