### PR TITLE
feat: add cross-account S3 access for content scanning

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -59,6 +59,11 @@ output "app_s3_iam_role_arn" {
   value       = try(aws_iam_role.app_s3[0].arn, null)
 }
 
+output "cross_account_s3_iam_role_arn" {
+  description = "Receiver IAM role ARN assumed by NvisionX for cross-account S3 access"
+  value       = try(aws_iam_role.cross_account_s3[0].arn, null)
+}
+
 output "bedrock_iam_role_arn" {
   description = "Bedrock IAM role ARN"
   value       = try(aws_iam_role.bedrock[0].arn, null)

--- a/pod-identity-roles.tf
+++ b/pod-identity-roles.tf
@@ -396,6 +396,112 @@ resource "aws_iam_role_policy_attachment" "app_s3" {
 }
 
 ################################################################################
+# Cross-Account S3 Assume — attaches to app_s3 role (NvisionX side)
+################################################################################
+
+locals {
+  cross_account_assume_enabled = var.create && var.enable_app_s3_access && var.enable_cross_account_s3_assume
+  cross_account_assume_resources = [
+    for name in var.cross_account_assume_role_names : "arn:aws:iam::*:role/${name}"
+  ]
+}
+
+data "aws_iam_policy_document" "app_s3_cross_account_assume" {
+  count = local.cross_account_assume_enabled ? 1 : 0
+
+  statement {
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = local.cross_account_assume_resources
+
+    dynamic "condition" {
+      for_each = var.cross_account_assume_target_org_id != "" ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:ResourceOrgID"
+        values   = [var.cross_account_assume_target_org_id]
+      }
+    }
+  }
+}
+
+resource "aws_iam_policy" "app_s3_cross_account_assume" {
+  count  = local.cross_account_assume_enabled ? 1 : 0
+  name   = "${aws_iam_role.app_s3[0].name}-cross-account-assume"
+  policy = data.aws_iam_policy_document.app_s3_cross_account_assume[0].json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "app_s3_cross_account_assume" {
+  count      = local.cross_account_assume_enabled ? 1 : 0
+  role       = aws_iam_role.app_s3[0].name
+  policy_arn = aws_iam_policy.app_s3_cross_account_assume[0].arn
+}
+
+################################################################################
+# Cross-Account S3 Receiver Role (deployed in target accounts)
+################################################################################
+
+data "aws_iam_policy_document" "cross_account_s3_trust" {
+  count = var.create && var.enable_cross_account_s3_role ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.cross_account_s3_source_role_arns
+    }
+
+    dynamic "condition" {
+      for_each = var.cross_account_s3_source_org_id != "" ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:PrincipalOrgID"
+        values   = [var.cross_account_s3_source_org_id]
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cross_account_s3_policy" {
+  count = var.create && var.enable_cross_account_s3_role ? 1 : 0
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = var.cross_account_s3_bucket_arn_patterns
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = [for arn in var.cross_account_s3_bucket_arn_patterns : "${arn}/*"]
+  }
+}
+
+resource "aws_iam_role" "cross_account_s3" {
+  count              = var.create && var.enable_cross_account_s3_role ? 1 : 0
+  name               = var.cross_account_s3_role_name
+  assume_role_policy = data.aws_iam_policy_document.cross_account_s3_trust[0].json
+  tags               = var.tags
+}
+
+resource "aws_iam_policy" "cross_account_s3" {
+  count  = var.create && var.enable_cross_account_s3_role ? 1 : 0
+  name   = "${var.cross_account_s3_role_name}-policy"
+  policy = data.aws_iam_policy_document.cross_account_s3_policy[0].json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cross_account_s3" {
+  count      = var.create && var.enable_cross_account_s3_role ? 1 : 0
+  role       = aws_iam_role.cross_account_s3[0].name
+  policy_arn = aws_iam_policy.cross_account_s3[0].arn
+}
+
+################################################################################
 # Bedrock IAM Role (Optional)
 ################################################################################
 

--- a/variables.tf
+++ b/variables.tf
@@ -526,6 +526,89 @@ variable "app_s3_bucket_arn_pattern" {
 }
 
 ################################################################################
+# Cross-Account S3 Access — NvisionX side (assume into target accounts)
+################################################################################
+
+variable "enable_cross_account_s3_assume" {
+  description = <<-EOF
+    Attach an sts:AssumeRole permission to the app_s3 role so EKS pods can
+    assume a standardized role in target accounts for content scanning.
+    Requires enable_app_s3_access = true.
+  EOF
+  type        = bool
+  default     = false
+}
+
+variable "cross_account_assume_role_names" {
+  description = <<-EOF
+    Standardized role names that the app_s3 role is allowed to assume in
+    target accounts. Each name expands to arn:aws:iam::*:role/<name>.
+  EOF
+  type        = list(string)
+  default     = ["nvisionx-s3-cross-account"]
+}
+
+variable "cross_account_assume_target_org_id" {
+  description = <<-EOF
+    Optional AWS Organization ID of the target accounts. When set, the
+    sts:AssumeRole permission is gated on aws:ResourceOrgID equals this value,
+    preventing assumption of look-alike roles outside the intended Org.
+    Leave empty to allow assumption regardless of target Org.
+  EOF
+  type        = string
+  default     = ""
+}
+
+################################################################################
+# Cross-Account S3 Access — receiver side (role assumed by NvisionX)
+################################################################################
+
+variable "enable_cross_account_s3_role" {
+  description = <<-EOF
+    Create the receiver IAM role assumed by the NvisionX EKS pods for
+    cross-account S3 content scanning. This is what gets deployed in target
+    (customer) accounts.
+  EOF
+  type        = bool
+  default     = false
+}
+
+variable "cross_account_s3_role_name" {
+  description = "Name of the receiver IAM role assumed by NvisionX."
+  type        = string
+  default     = "nvisionx-s3-cross-account"
+}
+
+variable "cross_account_s3_source_role_arns" {
+  description = <<-EOF
+    Source role ARNs allowed to assume the receiver role. Typically the
+    NvisionX EKS Pod Identity role ARN, e.g.
+    "arn:aws:iam::769537049595:role/eks-sandbox-app-s3-access".
+  EOF
+  type        = list(string)
+  default     = []
+}
+
+variable "cross_account_s3_source_org_id" {
+  description = <<-EOF
+    Optional AWS Organization ID of the source (NvisionX) account. When set,
+    the trust policy adds an aws:PrincipalOrgID condition to defense-in-depth
+    scope assumption to principals in this Org.
+  EOF
+  type        = string
+  default     = ""
+}
+
+variable "cross_account_s3_bucket_arn_patterns" {
+  description = <<-EOF
+    S3 bucket ARN patterns the receiver role is allowed to read. Supports
+    wildcards. Example: ["arn:aws:s3:::acme-prod-*"].
+  EOF
+  type        = list(string)
+  default     = ["arn:aws:s3:::*"]
+}
+
+################################################################################
 # VPC Flow Logs IAM Role
 ################################################################################
 


### PR DESCRIPTION
## Summary
- Extends the existing `app_s3` Pod Identity role with an `sts:AssumeRole` permission (gated on `enable_cross_account_s3_assume`) so EKS pods can assume a standardized role in target accounts. Optional `aws:ResourceOrgID` condition scopes assumption to a single AWS Org.
- Adds a new receiver role (gated on `enable_cross_account_s3_role`, default name `nvisionx-s3-cross-account`) with trust to a configurable source role ARN list (+ optional `aws:PrincipalOrgID` condition) and S3 read permissions on a configurable bucket ARN pattern list.
- Both flags default off — no behaviour change for existing consumers.

## New variables
**Assume side (NvisionX):**
- `enable_cross_account_s3_assume` (bool, default `false`)
- `cross_account_assume_role_names` (list, default `["nvisionx-s3-cross-account"]`)
- `cross_account_assume_target_org_id` (string, default `""`)

**Receiver side (target account):**
- `enable_cross_account_s3_role` (bool, default `false`)
- `cross_account_s3_role_name` (string, default `"nvisionx-s3-cross-account"`)
- `cross_account_s3_source_role_arns` (list, default `[]`)
- `cross_account_s3_source_org_id` (string, default `""`)
- `cross_account_s3_bucket_arn_patterns` (list, default `["arn:aws:s3:::*"]`)

## New output
- `cross_account_s3_iam_role_arn`

## Companion PRs
- nx-development-tf #25 — enables assume side in dev
- nx-integration-tf #34 — creates receiver role in integration

## Release plan
After this merges, cut a new tag (e.g. `v2026.04.30-1`) and flip `?ref=feat/cross-account-s3` to the tag in both companion PRs before merging them.

## Test plan
- [ ] `terraform validate` passes (verified locally)
- [ ] `terraform plan` against dev with `enable_cross_account_s3_assume = true` shows only the new policy + attachment on the existing `app_s3` role.
- [ ] `terraform plan` against integration with `enable_cross_account_s3_role = true` shows only the new role/policy/attachment.
- [ ] End-to-end: dev pod assumes `arn:aws:iam::022787320932:role/nvisionx-s3-cross-account` and reads from a `nvisionx*` bucket in integration.