### PR TITLE
fix: allow sts:TagSession on cross-account S3 assume

### DIFF
--- a/pod-identity-roles.tf
+++ b/pod-identity-roles.tf
@@ -410,8 +410,11 @@ data "aws_iam_policy_document" "app_s3_cross_account_assume" {
   count = local.cross_account_assume_enabled ? 1 : 0
 
   statement {
-    effect    = "Allow"
-    actions   = ["sts:AssumeRole"]
+    effect = "Allow"
+    # sts:TagSession is required because EKS Pod Identity forwards session
+    # tags during chained AssumeRole. Without it the call is rejected with
+    # "not authorized to perform: sts:TagSession on resource: <target role>".
+    actions   = ["sts:AssumeRole", "sts:TagSession"]
     resources = local.cross_account_assume_resources
 
     dynamic "condition" {
@@ -446,8 +449,10 @@ data "aws_iam_policy_document" "cross_account_s3_trust" {
   count = var.create && var.enable_cross_account_s3_role ? 1 : 0
 
   statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    # sts:TagSession must be allowed on the trust policy too — EKS Pod
+    # Identity forwards session tags during the chained AssumeRole call.
+    actions = ["sts:AssumeRole", "sts:TagSession"]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
## Summary
- Add `sts:TagSession` alongside `sts:AssumeRole` on both the source identity policy (`app_s3_cross_account_assume`) and the receiver trust policy (`cross_account_s3_trust`).
- Required because **EKS Pod Identity forwards session tags during chained `AssumeRole`** — without `sts:TagSession` the call fails with `AccessDenied`.

## Why
End-to-end test from `eks-development` (account `769537049595`) to integration (account `022787320932`) failed on first attempt:

```
User: arn:aws:sts::769537049595:assumed-role/eks-sandbox-app-s3-access/...
is not authorized to perform: sts:TagSession on resource:
arn:aws:iam::022787320932:role/nvisionx-s3-cross-account
```

After patching both sides via AWS CLI hotfix (source policy + receiver trust), the assume + `s3 ls` worked end-to-end. This PR codifies that fix so subsequent `terraform apply` doesn't revert it, and so it applies cleanly to every other environment (uat/demo/demo2/prod) when this module is consumed.

## Test plan
- [x] `terraform fmt` / `terraform validate` clean.
- [x] End-to-end validated in dev → integration (Pod Identity pod assumed receiver role, listed `s3://nvisionx-csvfiles-*` and `s3://nvisionx-cloudtrail-logs-*`).
- [ ] Cut new tag after merge (suggest `v2026.05.14-1`).
- [ ] Bump `nx-development-tf` and `nx-integration-tf` to the new tag and apply (will reconcile the hotfix that currently exists in AWS).
- [ ] Roll out to `nx-uat-tf` / `nx-demo-tf` / `nx-demo2-tf` / `nx-prod-tf` per the original ticket scope.