### PR TITLE
feat(bedrock): optional inference-profile access in IAM policy

### DIFF
--- a/pod-identity-roles.tf
+++ b/pod-identity-roles.tf
@@ -537,12 +537,20 @@ locals {
     "arn:aws:bedrock:*::foundation-model/${local.bedrock_provider_prefixes[provider]}*"
   ]
 
+  # Resources for invoke/streaming: foundation-model ARNs, plus inference-profile
+  # ARNs when enabled (invoking via a profile is authorized against the profile ARN
+  # as well as the underlying foundation-model ARN).
+  bedrock_invoke_resources = concat(
+    local.bedrock_model_arns,
+    var.bedrock_include_inference_profiles ? var.bedrock_inference_profile_arns : []
+  )
+
   # Build policy statements based on capabilities
   bedrock_invoke_statement = contains(var.bedrock_capabilities, "invoke") ? [merge(
     {
       Effect   = "Allow"
       Action   = ["bedrock:InvokeModel"]
-      Resource = local.bedrock_model_arns
+      Resource = local.bedrock_invoke_resources
     },
     length(var.bedrock_allowed_regions) > 0 ? {
       Condition = {
@@ -557,7 +565,7 @@ locals {
     {
       Effect   = "Allow"
       Action   = ["bedrock:InvokeModelWithResponseStream"]
-      Resource = local.bedrock_model_arns
+      Resource = local.bedrock_invoke_resources
     },
     length(var.bedrock_allowed_regions) > 0 ? {
       Condition = {

--- a/variables.tf
+++ b/variables.tf
@@ -424,6 +424,28 @@ variable "bedrock_custom_model_arns" {
   default     = ["arn:aws:bedrock:*::foundation-model/*"]
 }
 
+variable "bedrock_include_inference_profiles" {
+  description = <<-EOF
+    Append inference-profile ARNs to the invoke/streaming statements. Most current
+    Bedrock models (e.g. Anthropic Claude, cross-region profiles) are invoked through
+    an inference profile, and IAM authorizes the call against the inference-profile ARN
+    in addition to the underlying foundation-model ARN. Leave false to preserve the
+    foundation-model-only behavior for existing consumers.
+  EOF
+  type        = bool
+  default     = false
+}
+
+variable "bedrock_inference_profile_arns" {
+  description = <<-EOF
+    Inference-profile ARNs to allow when bedrock_include_inference_profiles = true. Examples:
+    - All profiles, all regions: ["arn:aws:bedrock:*:*:inference-profile/*"]
+    - Account-scoped: ["arn:aws:bedrock:*:123456789012:inference-profile/*"]
+  EOF
+  type        = list(string)
+  default     = ["arn:aws:bedrock:*:*:inference-profile/*"]
+}
+
 variable "bedrock_allowed_regions" {
   description = "List of AWS regions where Bedrock API calls are allowed. Empty list allows all regions. Provides additional security control beyond model ARNs."
   type        = list(string)


### PR DESCRIPTION
## Problem

The `bedrock` IAM policy only ever allows `foundation-model/*` ARNs. But most current Bedrock models — Anthropic Claude, and any **cross-region inference profile** — are invoked through an **inference-profile ARN**, and IAM authorizes `InvokeModel` against the inference-profile ARN *in addition to* the underlying foundation-model ARN. A foundation-model-only policy therefore gets `AccessDenied` on those calls.

This surfaced as drift: a live policy had `inference-profile/*` added by hand (it was never in this module), and a plan wanted to revert it — which would have broken Bedrock invocation. This PR makes that grant expressible in code.

## Change

Two new variables (no behavior change for existing consumers — default off):

- `bedrock_include_inference_profiles` (bool, default `false`) — when true, appends inference-profile ARNs to the **invoke** and **streaming** statements.
- `bedrock_inference_profile_arns` (list, default `["arn:aws:bedrock:*:*:inference-profile/*"]`).

Implementation: a new `local.bedrock_invoke_resources = concat(bedrock_model_arns, include ? inference_profile_arns : [])` feeds the invoke/streaming `Resource`. Provider-family scoping and the region `Condition` are untouched.

## Notes

- Default `false` ⇒ every current consumer renders an identical policy; no plan churn for them.
- A consumer that needs inference profiles sets `bedrock_include_inference_profiles = true` (and can narrow `bedrock_inference_profile_arns` to specific profiles/accounts if desired).
- `terraform fmt` clean.
