### PR TITLE
fix(bedrock): StringLike on aws:RequestedRegion to allow us-* wildcards

### DIFF
--- a/pod-identity-roles.tf
+++ b/pod-identity-roles.tf
@@ -554,7 +554,11 @@ locals {
     },
     length(var.bedrock_allowed_regions) > 0 ? {
       Condition = {
-        StringEquals = {
+        # StringLike (not StringEquals) so entries may use wildcards, e.g.
+        # ["us-*"] to cover all US regions reached by `us.` cross-region
+        # inference profiles. Literal values without wildcards behave
+        # identically to StringEquals, so this is safe for existing consumers.
+        StringLike = {
           "aws:RequestedRegion" = var.bedrock_allowed_regions
         }
       }
@@ -569,7 +573,11 @@ locals {
     },
     length(var.bedrock_allowed_regions) > 0 ? {
       Condition = {
-        StringEquals = {
+        # StringLike (not StringEquals) so entries may use wildcards, e.g.
+        # ["us-*"] to cover all US regions reached by `us.` cross-region
+        # inference profiles. Literal values without wildcards behave
+        # identically to StringEquals, so this is safe for existing consumers.
+        StringLike = {
           "aws:RequestedRegion" = var.bedrock_allowed_regions
         }
       }


### PR DESCRIPTION
## What
Switch the Bedrock `InvokeModel` / `InvokeModelWithResponseStream` IAM statements from `StringEquals` to `StringLike` on the `aws:RequestedRegion` condition key.

## Why
`StringEquals` requires the request region to exactly match an entry in `bedrock_allowed_regions`. `us.` **cross-region inference profiles** (e.g. `meta.llama4-maverick-17b-instruct-v1:0`) route requests across all four commercial US regions. With the dev list pinned to `["us-east-1","us-east-2"]`, the knowledge-hub workload got:

```
AccessDenied ... not authorized to perform: bedrock:InvokeModel on resource:
arn:aws:bedrock:us-west-2::foundation-model/meta.llama4-maverick-17b-instruct-v1:0
```

`StringLike` lets consumers pass wildcard regions like `["us-*"]` to cover the full US inference geography in one entry.

## Safety
`StringLike` with literal values that contain no wildcard behaves identically to `StringEquals`, so existing consumers passing explicit region lists are unaffected. No change to resources or actions.

## Follow-up
Consumed by `nx-development-tf` once a new module tag is cut and its `ref=` is bumped (separate PR sets `bedrock_allowed_regions = ["us-*"]`). Live dev policy was already hand-patched to this shape (v9); this reconciles the module so the next apply doesn't regress it.